### PR TITLE
feat: ignore Vite internal requests in middleware

### DIFF
--- a/.changeset/wise-friends-bow.md
+++ b/.changeset/wise-friends-bow.md
@@ -1,0 +1,5 @@
+---
+"blogger-plugin": patch
+---
+
+Ignore Vite internal requests (/@fs/, /@vite/, etc.) in middleware

--- a/packages/blogger-plugin/src/vite.ts
+++ b/packages/blogger-plugin/src/vite.ts
@@ -386,7 +386,8 @@ function useServerMiddleware(server: ViteDevServer | PreviewServer, ctx: Blogger
         !url ||
         !req.method ||
         !['GET', 'HEAD'].includes(req.method.toUpperCase()) ||
-        htmlPathnames.includes(url.pathname.replace(/\/+/g, '/'))
+        htmlPathnames.includes(url.pathname.replace(/\/+/g, '/')) ||
+        url.pathname.startsWith('/@')
       ) {
         next();
         return;


### PR DESCRIPTION
Ignore Vite internal requests (`/@fs/`, `/@vite/`, etc.) in middleware